### PR TITLE
fix: fail task and release machine on unexpected guest errors

### DIFF
--- a/lib/cuckoo/core/analysis_manager.py
+++ b/lib/cuckoo/core/analysis_manager.py
@@ -22,7 +22,7 @@ from lib.cuckoo.common.objects import File
 from lib.cuckoo.common.path_utils import path_delete, path_exists, path_mkdir
 from lib.cuckoo.common.utils import convert_to_printable, create_folder, get_memdump_path
 from lib.cuckoo.core.database import Database, _Database
-from lib.cuckoo.core.data.task import TASK_COMPLETED, TASK_PENDING, TASK_RUNNING, Task
+from lib.cuckoo.core.data.task import TASK_COMPLETED, TASK_FAILED_ANALYSIS, TASK_PENDING, TASK_RUNNING, Task
 from lib.cuckoo.core.data.machines import Machine
 from lib.cuckoo.core.data.guests import Guest
 from lib.cuckoo.core.guest import GuestManager
@@ -309,6 +309,7 @@ class AnalysisManager(threading.Thread):
     def machine_running(self) -> Generator[None, None, None]:
         assert self.machinery_manager and self.machine and self.guest
 
+        machine_is_dead = False
         try:
             with self.db.session.begin():
                 self.machinery_manager.start_machine(self.machine)
@@ -322,6 +323,7 @@ class AnalysisManager(threading.Thread):
             # This machine has turned dead, so we'll throw an exception
             # which informs the AnalysisManager that it should analyze
             # this task again with another available machine.
+            machine_is_dead = True
             self.log.exception(str(e))
 
             # Remove the guest from the database, so that we can assign a
@@ -337,6 +339,14 @@ class AnalysisManager(threading.Thread):
             shutil.rmtree(self.storage)
 
             raise CuckooDeadMachine(self.machine.name) from e
+        finally:
+            # Always stop/release the machine, even on an unexpected error, so the VM isn't left
+            # running and locked. The dead-machine branch already removed it, so skip that case.
+            if not machine_is_dead:
+                self._stop_and_release_machine()
+
+    def _stop_and_release_machine(self) -> None:
+        assert self.machinery_manager and self.machine
 
         with self.db.session.begin():
             try:
@@ -482,6 +492,15 @@ class AnalysisManager(threading.Thread):
                 # Put the task back in pending so that the schedule can attempt to choose a new machine.
                 self.db.set_status(self.task.id, TASK_PENDING)
             raise
+        except Exception:
+            # Any other failure must still mark the task terminal and release the machine, or it stays
+            # "running" forever (the analysis timeout only starts once the guest wait begins).
+            self.log.exception("Failure during analysis of task #%s", self.task.id)
+            with self.db.session.begin():
+                self.db.set_status(self.task.id, TASK_FAILED_ANALYSIS)
+                if hasattr(self, "machine") and self.machine:
+                    self.db.unlock_machine(self.machine)
+            return
         else:
             with self.db.session.begin():
                 self.db.set_status(self.task.id, TASK_COMPLETED)

--- a/tests/test_analysis_manager.py
+++ b/tests/test_analysis_manager.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from lib.cuckoo.common.abstracts import Machinery
 from lib.cuckoo.common.config import Config, ConfigMeta
 from lib.cuckoo.core.analysis_manager import AnalysisManager
-from lib.cuckoo.core.data.task import TASK_RUNNING, Task
+from lib.cuckoo.core.data.task import TASK_FAILED_ANALYSIS, TASK_RUNNING, Task
 from lib.cuckoo.core.data.guests import Guest
 from lib.cuckoo.core.data.machines import Machine
 from lib.cuckoo.core.database import _Database
@@ -440,3 +440,37 @@ class TestAnalysisManager:
         assert analysis_man.init_storage() is True
         mocker.patch("lib.cuckoo.core.database._Database.view_sample", return_value=mock_sample())
         assert analysis_man.category_checks() is True
+
+    def test_machine_running_releases_machine_on_unexpected_error(
+        self, db: _Database, task: Task, machine: Machine, machinery_manager: MachineryManager, mocker: MockerFixture
+    ):
+        # A non-CuckooMachineError raised inside the context (e.g. an HTTP error while uploading the
+        # sample to the guest) must still stop and release the machine, otherwise the VM stays running
+        # and locked forever.
+        mgr = AnalysisManager(task=task, machine=machine, machinery_manager=machinery_manager)
+        with db.session.begin():
+            mgr.prepare_task_and_machine_to_start()
+            db.session.expunge_all()
+
+        mocker.patch.object(machinery_manager, "start_machine")
+        stop_machine = mocker.patch.object(machinery_manager, "stop_machine")
+        release = mocker.patch.object(machinery_manager.machinery, "release")
+
+        with pytest.raises(RuntimeError):
+            with mgr.machine_running():
+                raise RuntimeError("guest upload failed")
+
+        stop_machine.assert_called_once()
+        release.assert_called_once()
+
+    def test_launch_analysis_marks_failed_on_unexpected_error(self, db: _Database, task: Task, mocker: MockerFixture):
+        # Any unexpected failure during analysis must drive the task to a terminal state, otherwise it
+        # stays "running" forever (never times out, since the timeout only applies during the guest wait).
+        task_id = task.id
+        mgr = AnalysisManager(task=task)
+        mocker.patch.object(mgr, "perform_analysis", side_effect=RuntimeError("guest returned 500"))
+
+        mgr.launch_analysis()
+
+        with db.session.begin():
+            assert db.session.get(Task, task_id).status == TASK_FAILED_ANALYSIS


### PR DESCRIPTION
## Problem

When the guest agent returns an error during analysis — e.g. an HTTP **500** from `/store` while the host uploads the sample — the resulting `requests.HTTPError` escapes CAPE's error handling and **orphans the task**: the VM is left running, the machine stays locked, and the task sits in `running` forever. The analysis timeout never fires because it only applies once `wait_for_completion()` has begun, which this never reaches.

We hit this in production: three submissions whose sample filename collided with a pre-existing path in the guest's `%TEMP%` each 500'd on upload and left all three machines locked for **3 days** until manually cleaned up.

### Root cause (`lib/cuckoo/core/analysis_manager.py`)

- **`machine_running()`** — the `stop_machine()` + `release()` cleanup sat *after* the `try/except`, so it only ran on the no-error path. The `except` only catches `(CuckooMachineError, CuckooGuestCriticalTimeout)`; any other exception through `yield` skipped cleanup entirely → VM left running + machine locked.
- **`launch_analysis()`** — only finalized task status for `CuckooDeadMachine` (→ `pending`) or clean completion (→ `completed`). Any other exception propagated out with the task left `running`.

## Fix

- `machine_running()`: always stop/release the machine via a `finally` block (extracted into `_stop_and_release_machine()`), skipping only the dead-machine case which already removes the machine.
- `launch_analysis()`: on any unexpected exception, mark the task `failed_analysis` and unlock the machine.

## Tests

Added regression tests in `tests/test_analysis_manager.py`:
- `test_machine_running_releases_machine_on_unexpected_error`
- `test_launch_analysis_marks_failed_on_unexpected_error`

`tests/test_analysis_manager.py`: **19 passed, 5 skipped** (pre-existing data-file skips).